### PR TITLE
use golang-builder like other concourse resources now do

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 ARG base_image
+ARG builder_image=concourse/golang-builder
+
+FROM ${builder_image} as builder
+WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+ENV CGO_ENABLED 0
+
+RUN go build -o /assets/in ./cmd/in
+RUN go build -o /assets/out ./cmd/out
+RUN go build -o /assets/check ./cmd/check
 
 FROM ${base_image}
 
-ADD check /opt/resource/check
-ADD in /opt/resource/in
-ADD out /opt/resource/out
-
+COPY --from=builder assets/ /opt/resource/
 RUN chmod +x /opt/resource/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the dockerfile to use the golang-builder image to actually compile the commands. Concourse switched to this method for the resource repos, but this one was never updated to follow this new method

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Setting up the code to properly compile
