### PR TITLE
adds tests to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,18 @@ ENV CGO_ENABLED 0
 RUN go build -o /assets/in ./cmd/in
 RUN go build -o /assets/out ./cmd/out
 RUN go build -o /assets/check ./cmd/check
+RUN set -e; for pkg in $(go list ./... | grep -v "acceptance"); do \
+    go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+    done
+
+FROM builder AS tests
+COPY --from=builder /tests /go-tests
+COPY --from=builder /src/bosh/fixtures /go-tests/fixtures
+WORKDIR /go-tests
+RUN set -e; for test in /go-tests/*.test; do \
+    $test; \
+    done
+
 
 FROM ${base_image}
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds tests that we can run to the Dockerfile

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Adding tests
